### PR TITLE
Error codes added and race conditions fixed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,4 @@ cargo test --release -- --ignored --nocapture
 - `PROC_LIMIT` is parsed but never used
 - On `u128` ID overflow, `enqueue` wraps the next ID back to 1, which may collide with an older message still in `self.queue` and silently overwrite it (see `TODO(note)` in `src/net/queue.rs`)
 - `read_buffer` has a `MAX_PAYLOAD_SIZE` guard (4 GB) that rejects oversized payloads before buffering
-- `get_queue` returns a cloned `Arc<Mutex<Queue>>`. After it returns, a concurrent `DeleteQ` can remove the queue from both maps. All handlers using `get_queue` then operate on an orphaned queue — writes succeed silently but data is lost (see `TODO(bug)` in `src/net/server.rs`)
-- UpdateQ handler updates `auto_fail` and `fail_timeout` under separate Mutex acquisitions, so a concurrent Dequeue between them can read a half-updated config (see `TODO(bug)` in `src/net/server.rs`)
 - Per-queue `auto_fail`: when enabled, after a Dequeue the server sleeps for `fail_timeout` **milliseconds** and then NACKs the just-sent message via `Queue::unlock`, putting it back on the queue for redelivery. An `is_locked` guard (held under the same Mutex acquisition as `unlock`) prevents both panic and stale NACK if the client acks first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ cargo test --release -- --ignored --nocapture
 
 **Response:** `[1 byte status][8 bytes payload_size][payload]`
 - Status `1` = Succeeded, `2` = Failed
+- Failed responses carry a 2-byte `ErrorCode` payload (big-endian `u16`). Error codes are defined in `src/errors.rs` and grouped by category: 0–99 general/protocol, 100–199 queue-level, 200–299 message-level, 300–399 config/parsing.
 
 ### Key Types
 
@@ -71,6 +72,7 @@ cargo test --release -- --ignored --nocapture
 | `Server` | `src/net/server.rs` | TCP listener; accepts connections and hands to `Pool` |
 | `Pool` | `src/net/server.rs` | Worker thread pool with pressure-based dispatch |
 | `Queue` | `src/net/queue.rs` | Named message queue with lock-to-read / ack semantics |
+| `ErrorCode` | `src/errors.rs` | `#[repr(u16)]` enum of typed error codes returned in Failed response payloads |
 
 ### Tests
 
@@ -96,4 +98,6 @@ cargo test --release -- --ignored --nocapture
 - `PROC_LIMIT` is parsed but never used
 - On `u128` ID overflow, `enqueue` wraps the next ID back to 1, which may collide with an older message still in `self.queue` and silently overwrite it (see `TODO(note)` in `src/net/queue.rs`)
 - `read_buffer` has a `MAX_PAYLOAD_SIZE` guard (4 GB) that rejects oversized payloads before buffering
+- `get_queue` returns a cloned `Arc<Mutex<Queue>>`. After it returns, a concurrent `DeleteQ` can remove the queue from both maps. All handlers using `get_queue` then operate on an orphaned queue — writes succeed silently but data is lost (see `TODO(bug)` in `src/net/server.rs`)
+- UpdateQ handler updates `auto_fail` and `fail_timeout` under separate Mutex acquisitions, so a concurrent Dequeue between them can read a half-updated config (see `TODO(bug)` in `src/net/server.rs`)
 - Per-queue `auto_fail`: when enabled, after a Dequeue the server sleeps for `fail_timeout` **milliseconds** and then NACKs the just-sent message via `Queue::unlock`, putting it back on the queue for redelivery. An `is_locked` guard (held under the same Mutex acquisition as `unlock`) prevents both panic and stale NACK if the client acks first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Review Rules
+
+- **Do not modify source code** unless explicitly asked. During reviews: leave/modify/remove TODOs freely, add/update/remove tests freely, and document suggested fixes in CLAUDE.md — but do not change actual logic or code.
+
 ## Project Overview
 
 DataBroker is a tutorial Rust TCP-based message queue. Clients connect and issue commands over a binary protocol. Named queues are shared across all connected clients. It's explicitly a learning project — the codebase contains many TODO comments documenting known bugs and design issues.
@@ -91,5 +95,5 @@ cargo test --release -- --ignored --nocapture
 - `command` field in `RequestMessage` is stored but never read after construction
 - `PROC_LIMIT` is parsed but never used
 - On `u128` ID overflow, `enqueue` wraps the next ID back to 1, which may collide with an older message still in `self.queue` and silently overwrite it (see `TODO(note)` in `src/net/queue.rs`)
-- `read_buffer` has no upper bound on `payload_size`, so a client can request an arbitrarily large `BytesMut` allocation (DoS surface)
+- `read_buffer` has a `MAX_PAYLOAD_SIZE` guard (4 GB) that rejects oversized payloads before buffering
 - Per-queue `auto_fail`: when enabled, after a Dequeue the server sleeps for `fail_timeout` **milliseconds** and then NACKs the just-sent message via `Queue::unlock`, putting it back on the queue for redelivery. An `is_locked` guard (held under the same Mutex acquisition as `unlock`) prevents both panic and stale NACK if the client acks first.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "DataBroker"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bytes",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "DataBroker"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "DataBroker"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "DataBroker"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 
 [dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,105 @@
+/// Error codes returned in Failed responses (status byte = 2).
+///
+/// Codes are grouped by category:
+///   0–99    General / protocol errors
+///   100–199 Queue-level errors
+///   200–299 Message-level errors
+///   300–399 Config / payload parsing errors
+#[repr(u16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    // ── 0–99: General / protocol ──────────────────────────────────────
+    /// Unrecognised command byte in the request header.
+    UnknownRequestType          = 0,
+    /// `RequestMessage::new()` failed to parse the incoming buffer.
+    RequestParseError           = 1,
+
+    // ── 100–199: Queue-level errors ───────────────────────────────────
+    /// Queue name does not map to any UUID (get_queue → "Hash not found").
+    QueueHashNotFound           = 100,
+    /// UUID exists in `queue_names` but not in `queue` map (get_queue → "Queue not found").
+    QueueNotFound               = 101,
+    /// Attempted to create a queue that already exists (CreateQ).
+    QueueAlreadyExists          = 102,
+    /// Attempted to delete a queue that does not exist (DeleteQ).
+    QueueDoesNotExist           = 103,
+    /// Queue is empty — no messages to operate on.
+    QueueIsEmpty                = 104,
+
+    // ── 200–299: Message-level errors ─────────────────────────────────
+    /// Payload is too short to contain a 16-byte message ID.
+    PayloadMissingMessageId     = 200,
+    /// The referenced message ID does not exist in the queue.
+    NoSuchMessageId             = 201,
+    /// The next message is already locked by another client (Dequeue / lock_to_read).
+    MessageAlreadyLocked        = 202,
+    /// No locked message found for the given client (dequeue without explicit ID).
+    NoSuchMessageIdLocked       = 203,
+    /// The message is not locked by the requesting client (dequeue / unlock).
+    MessageNotLockedByClient    = 204,
+    /// Message is not in the queue (requeue / update_message).
+    MessageNotInQueue           = 205,
+
+    // ── 300–399: Config / payload parsing errors ──────────────────────
+    /// UpdateQ payload is shorter than 1 byte.
+    InvalidConfigPayloadSize    = 300,
+    /// NetQueueConfig bytes are empty.
+    ConfigBytesEmpty            = 301,
+    /// NetQueueConfig auto_fail flag set but byte missing.
+    ConfigInvalidAutoFail       = 302,
+    /// NetQueueConfig fail_timeout flag set but not enough bytes.
+    ConfigInvalidFailTimeout    = 303,
+}
+
+impl ErrorCode {
+    pub fn as_u16(self) -> u16 {
+        self as u16
+    }
+
+    pub fn from_u16(value: u16) -> Option<Self> {
+        match value {
+            0   => Some(Self::UnknownRequestType),
+            1   => Some(Self::RequestParseError),
+            100 => Some(Self::QueueHashNotFound),
+            101 => Some(Self::QueueNotFound),
+            102 => Some(Self::QueueAlreadyExists),
+            103 => Some(Self::QueueDoesNotExist),
+            104 => Some(Self::QueueIsEmpty),
+            200 => Some(Self::PayloadMissingMessageId),
+            201 => Some(Self::NoSuchMessageId),
+            202 => Some(Self::MessageAlreadyLocked),
+            203 => Some(Self::NoSuchMessageIdLocked),
+            204 => Some(Self::MessageNotLockedByClient),
+            205 => Some(Self::MessageNotInQueue),
+            300 => Some(Self::InvalidConfigPayloadSize),
+            301 => Some(Self::ConfigBytesEmpty),
+            302 => Some(Self::ConfigInvalidAutoFail),
+            303 => Some(Self::ConfigInvalidFailTimeout),
+            _   => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownRequestType        => write!(f, "Unknown request type"),
+            Self::RequestParseError         => write!(f, "Failed to parse request message"),
+            Self::QueueHashNotFound         => write!(f, "Hash not found"),
+            Self::QueueNotFound             => write!(f, "Queue not found"),
+            Self::QueueAlreadyExists        => write!(f, "Queue already created"),
+            Self::QueueDoesNotExist         => write!(f, "Queue does not exist"),
+            Self::QueueIsEmpty              => write!(f, "Queue is empty"),
+            Self::PayloadMissingMessageId   => write!(f, "Payload doesn't contain message_id"),
+            Self::NoSuchMessageId           => write!(f, "No such message id"),
+            Self::MessageAlreadyLocked      => write!(f, "Queue message already locked"),
+            Self::NoSuchMessageIdLocked     => write!(f, "No such message id locked"),
+            Self::MessageNotLockedByClient  => write!(f, "Queue message is not locked by client"),
+            Self::MessageNotInQueue         => write!(f, "Message is not in queue"),
+            Self::InvalidConfigPayloadSize  => write!(f, "Invalid config payload size"),
+            Self::ConfigBytesEmpty          => write!(f, "Empty bytes"),
+            Self::ConfigInvalidAutoFail     => write!(f, "Invalid bytes auto_success"),
+            Self::ConfigInvalidFailTimeout  => write!(f, "Invalid bytes success_timeout"),
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,6 +13,10 @@ pub enum ErrorCode {
     UnknownRequestType          = 0,
     /// `RequestMessage::new()` failed to parse the incoming buffer.
     RequestParseError           = 1,
+    /// Failed to send response.
+    ResponseFailedError         = 2,
+    /// Declared payload_size exceeds MAX_PAYLOAD_SIZE.
+    PayloadTooLarge             = 3,
 
     // ── 100–199: Queue-level errors ───────────────────────────────────
     /// Queue name does not map to any UUID (get_queue → "Hash not found").
@@ -56,10 +60,16 @@ impl ErrorCode {
         self as u16
     }
 
+    pub fn to_payload(self) -> Vec<u8> {
+        self.as_u16().to_be_bytes().to_vec()
+    }
+
     pub fn from_u16(value: u16) -> Option<Self> {
         match value {
             0   => Some(Self::UnknownRequestType),
             1   => Some(Self::RequestParseError),
+            2   => Some(Self::ResponseFailedError),
+            3   => Some(Self::PayloadTooLarge),
             100 => Some(Self::QueueHashNotFound),
             101 => Some(Self::QueueNotFound),
             102 => Some(Self::QueueAlreadyExists),
@@ -85,6 +95,8 @@ impl std::fmt::Display for ErrorCode {
         match self {
             Self::UnknownRequestType        => write!(f, "Unknown request type"),
             Self::RequestParseError         => write!(f, "Failed to parse request message"),
+            Self::ResponseFailedError        => write!(f, "Failed to send response"),
+            Self::PayloadTooLarge           => write!(f, "Payload exceeds maximum size"),
             Self::QueueHashNotFound         => write!(f, "Hash not found"),
             Self::QueueNotFound             => write!(f, "Queue not found"),
             Self::QueueAlreadyExists        => write!(f, "Queue already created"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod net;
 mod config;
 mod tests;
+mod errors;
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/net/queue.rs
+++ b/src/net/queue.rs
@@ -1,14 +1,16 @@
 use std::collections::{HashMap};
 use std::io::ErrorKind;
 use std::sync::Arc;
+use bytes::BytesMut;
 use tokio::sync::RwLock;
+use uuid::Bytes;
 
 const MAGIC_DRAIN_VEC: usize = 10usize;
 const NET_QUEUE_CONFIG_SIZE: usize = 1usize + 1usize + 8usize;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct QueueMessage {
-    payload: Vec<u8>,
+    payload: BytesMut,
     publisher_id: u128,
     timestamp: u64,
     locked_by: Option<u128>,
@@ -39,7 +41,7 @@ pub(crate) struct Queue {
     config: QueueConfig,
 }
 impl QueueMessage {
-    pub fn new(payload: Vec<u8>, publisher_id: u128) -> Self {
+    pub fn new(payload: BytesMut, publisher_id: u128) -> Self {
         Self {
             payload,
             publisher_id,
@@ -169,7 +171,7 @@ impl Queue {
     pub fn update_config_fail_timeout(&mut self, value: u64) {
         self.config.fail_timeout = value;
     }
-    pub fn enqueue(&mut self, payload: Vec<u8>, publisher_id: u128) -> Result<(), std::io::Error> {
+    pub fn enqueue(&mut self, payload: BytesMut, publisher_id: u128) -> Result<(), std::io::Error> {
         let mut id;
         if self.order.is_empty() {
             id = 1;
@@ -219,7 +221,7 @@ impl Queue {
             head = get_meta_as_vec(self.next_id.unwrap(), &message);
         }
 
-        head.append(&mut self.queue[&self.next_id.unwrap()].payload.clone());
+        head.append(&mut self.queue[&self.next_id.unwrap()].payload.to_vec());
         let payload: Vec<u8> = head;
 
         let mut iter = self.order.iter();
@@ -398,7 +400,7 @@ impl Queue {
         }
         Ok(result)
     }
-    pub fn update_message(&mut self, message_id: u128, payload: Vec<u8>) -> Result<(), std::io::Error> {
+    pub fn update_message(&mut self, message_id: u128, payload: BytesMut) -> Result<(), std::io::Error> {
         if self.order.is_empty() {
             return Err(std::io::Error::new(ErrorKind::InvalidData, "Queue is empty"));
         }

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -291,12 +291,6 @@ impl Server {
         println!("New connection from {}", addr);
         pool.spawn(async move { self.handle_connection(socket, stop_word.clone()).await }).await
     }
-    // TODO(bug): get_queue returns a cloned Arc<Mutex<Queue>>. After this returns, a
-    // concurrent DeleteQ can remove the queue from both maps. All handlers that use
-    // get_queue (Enqueue, Dequeue, DeleteM, Succeeded, Failed, Requeue, UpdateM, UpdateQ)
-    // then operate on an orphaned queue — writes succeed silently but data is lost.
-    // Fix: either hold the read guard for the duration of the operation, or accept this
-    // as a benign race (the operation was in-flight when the delete happened).
     async fn get_queue(&self, queue_lock: &RwLockReadGuard<'_, HashMap<Uuid, Arc<Mutex<Queue>>>> , queue_name: &String) -> Result<Arc<Mutex<Queue>>, ErrorCode> {
         let hash = self.queue_names.read().await.get(queue_name).cloned();
         match hash {
@@ -338,6 +332,7 @@ impl Server {
             if duration == 0u64 {
                 return Ok(())
             }
+            drop(lock);
             tokio::time::sleep(Duration::from_millis(duration)).await;
             {
                 let mut lock= queue.lock().await;
@@ -722,15 +717,12 @@ impl Server {
                                     let payload = message.payload.to_vec();
                                     match NetQueueConfig::from_be_bytes(payload) {
                                         Ok((net_queue_config, _)) => {
-                                            // TODO(bug): auto_fail and fail_timeout are updated under
-                                            // separate lock acquisitions. A concurrent Dequeue between
-                                            // them can read a half-updated config. Fix: hold a single
-                                            // lock for both updates.
+                                            let mut lock = queue.lock().await;
                                             if net_queue_config.auto_fail().is_some() {
-                                                queue.lock().await.update_config_auto_fail(net_queue_config.auto_fail().unwrap());
+                                                lock.update_config_auto_fail(net_queue_config.auto_fail().unwrap());
                                             }
                                             if net_queue_config.fail_timeout().is_some() {
-                                                queue.lock().await.update_config_fail_timeout(net_queue_config.fail_timeout().unwrap());
+                                                lock.update_config_fail_timeout(net_queue_config.fail_timeout().unwrap());
                                             }
                                             let response = ResponseMessage::new(Response::Succeeded, vec!());
                                             server.clone().send_response(writer, &response).await;

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -3,17 +3,19 @@ use std::io;
 use std::io::Read;
 use std::net::{SocketAddr, SocketAddrV4};
 use std::pin::Pin;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize};
+use std::sync::{Arc, MutexGuard};
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::atomic::Ordering::Relaxed;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, RwLockReadGuard};
 use bytes::BytesMut;
 use tokio::net::tcp::OwnedWriteHalf;
 use uuid::Uuid;
 use crate::config::Config;
+use crate::errors::ErrorCode;
+use crate::errors::ErrorCode::{RequestParseError, ResponseFailedError};
 use crate::net::queue::{NetQueueConfig, Queue};
 
 const COMMAND_SIZE: usize = 1usize;
@@ -206,18 +208,18 @@ impl ResponseMessage {
     }
 }
 macro_rules! send_failed {
-        ($server: expr, $writer: expr) => {
+        ($server: expr, $writer: expr, $err: expr) => {
             {
-                let response = ResponseMessage::new(Response::Failed, vec!());
+                let response = ResponseMessage::new(Response::Failed, $err.as_u16().to_be_bytes().to_vec());
                 $server.send_response($writer, &response).await;
                 return;
             }
         };
     }
 macro_rules! invalid_message_id {
-    ($server: expr, $writer: expr) => {
+    ($server: expr, $writer: expr, $err: expr) => {
         {
-            let response = ResponseMessage::new(Response::Failed, vec!());
+            let response = ResponseMessage::new(Response::Failed, $err.as_u16().to_be_bytes().to_vec());
             $server.clone().send_response($writer, &response).await;
             println!("Payload doesn't contain message_id!");
             return;
@@ -289,66 +291,73 @@ impl Server {
         println!("New connection from {}", addr);
         pool.spawn(async move { self.handle_connection(socket, stop_word.clone()).await }).await
     }
-    async fn get_queue(&self, queue_name: &String) -> Result<Arc<Mutex<Queue>>, std::io::Error> {
+    // TODO(bug): get_queue returns a cloned Arc<Mutex<Queue>>. After this returns, a
+    // concurrent DeleteQ can remove the queue from both maps. All handlers that use
+    // get_queue (Enqueue, Dequeue, DeleteM, Succeeded, Failed, Requeue, UpdateM, UpdateQ)
+    // then operate on an orphaned queue — writes succeed silently but data is lost.
+    // Fix: either hold the read guard for the duration of the operation, or accept this
+    // as a benign race (the operation was in-flight when the delete happened).
+    async fn get_queue(&self, queue_lock: &RwLockReadGuard<'_, HashMap<Uuid, Arc<Mutex<Queue>>>> , queue_name: &String) -> Result<Arc<Mutex<Queue>>, ErrorCode> {
         let hash = self.queue_names.read().await.get(queue_name).cloned();
         match hash {
             Some(hash) => {
-                let queue = self.queue.read().await.get(&hash).cloned();
+                let queue = queue_lock.get(&hash).cloned();
                 match queue {
                     Some(queue) => {
                         Ok(queue.clone()) },
                     None => {
-                        Err(std::io::Error::new(std::io::ErrorKind::NotFound, "Queue not found")) },
+                        Err(ErrorCode::QueueNotFound) },
                 }
             }
             None => {
-                Err(std::io::Error::new(std::io::ErrorKind::NotFound, "Hash not found"))
+                Err(ErrorCode::QueueHashNotFound)
             }
         }
     }
-    async fn lock_and_dequeue_message(self, stream: Arc<Mutex<OwnedWriteHalf>>, queue_name: String, client_id: u128) -> Result<(), std::io::Error> {
-        match self.get_queue(&queue_name).await {
-            Ok(queue) => {
-                let message = queue.lock().await.lock_to_read(client_id).await;
-                match message {
-                    Ok((message, message_id)) => {
-                        let message = ResponseMessage::new(Response::Succeeded, message);
-                        stream.lock().await.write_all(&message.to_u8()).await?;
-                        if queue.lock().await.get_config_auto_fail() {
-                            let duration = queue.lock().await.get_config_fail_timeout();
-                            if duration == 0u64 {
-                                return Ok(())
-                            }
-                            tokio::time::sleep(Duration::from_millis(duration)).await;
-                            {
-                                let mut lock= queue.lock().await;
-                                if lock.is_locked(client_id, message_id.unwrap()).await {
-                                    match lock.unlock(client_id, message_id).await {
-                                        Ok(_) => {
-                                            println!("[worker {:?}] auto unlock message", std::thread::current().id());
-                                        },
-                                        Err(err) => {
-                                            println!("[worker {:?}] auto unlock message error {:?}", std::thread::current().id(), err);
-                                        }
-                                    }
-                                }
-                            }
+    async fn lock_and_dequeue_message(self, stream: Arc<Mutex<OwnedWriteHalf>>, queue_name: String, client_id: u128) -> Result<(), ErrorCode> {
+        let queue_lock = self.queue.read().await;
+        let queue = self.get_queue(&queue_lock, &queue_name).await?;
+        let message = queue.lock().await.lock_to_read(client_id).await.map_err(|err| {
+            let code = match err.to_string().as_str() {
+                "No such message id" => ErrorCode::NoSuchMessageId,
+                "Queue message already locked" => ErrorCode::MessageAlreadyLocked,
+                _ => ErrorCode::QueueIsEmpty,
+            };
+            println!("[worker {:?}] send_message error {:?}", std::thread::current().id(), err);
+            code
+        })?;
+        let (message, message_id) = message;
+        let response = ResponseMessage::new(Response::Succeeded, message);
+        stream.lock().await.write_all(&response.to_u8()).await.map_err(|err| {
+            println!("[worker {:?}] send_message error {:?}", std::thread::current().id(), err);
+            ErrorCode::ResponseFailedError
+        })?;
+        let lock = queue.lock().await;
+        if lock.get_config_auto_fail() {
+            let duration = lock.get_config_fail_timeout();
+            if duration == 0u64 {
+                return Ok(())
+            }
+            tokio::time::sleep(Duration::from_millis(duration)).await;
+            {
+                let mut lock= queue.lock().await;
+                if lock.is_locked(client_id, message_id.unwrap()).await {
+                    match lock.unlock(client_id, message_id).await {
+                        Ok(_) => {
+                            println!("[worker {:?}] auto unlock message", std::thread::current().id());
+                        },
+                        Err(err) => {
+                            println!("[worker {:?}] auto unlock message error {:?}", std::thread::current().id(), err);
                         }
-                        return Ok(())
-                    }
-                    Err(err) => {
-                        println!("[worker {:?}] send_message error {:?}", std::thread::current().id(), err);
                     }
                 }
             }
-            Err(err) => {
-                println!("[worker {:?}] send_message error {:?}", std::thread::current().id(), err);
-            }
         }
-        Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Failed to send message"))
+        Ok(())
     }
     async fn dequeue_message_sent(self, queue_name: String, client_id: u128, message_id: Option<u128>) -> Result<(), std::io::Error> {
-        match self.get_queue(&queue_name).await {
+        let queue_lock = self.queue.read().await;
+        match self.get_queue(&queue_lock, &queue_name).await {
             Ok(queue) => {
                 let cleared = queue.lock().await.dequeue(client_id, message_id).await;
                 return match cleared {
@@ -366,11 +375,12 @@ impl Server {
         }
         Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Failed to clear message sent"))
     }
-    async fn send_response(self, stream: Arc<Mutex<OwnedWriteHalf>>, response: &ResponseMessage) {
+    async fn send_response(self, stream: Arc<Mutex<OwnedWriteHalf>>, response: &ResponseMessage) -> Option<ErrorCode>{
         match stream.lock().await.write_all(&response.to_u8()).await {
-            Ok(_) => (),
+            Ok(_) => { None },
             Err(err) => {
                 println!("[worker {:?}] response error {:?}", std::thread::current().id(), err);
+                Some(ResponseFailedError)
             }
         }
     }
@@ -402,7 +412,7 @@ impl Server {
                 let command = Request::from_u8(buffer[0]);
                 let writer = stream_write.clone();
                 if command.is_err() {
-                    let response = ResponseMessage::new(Response::Failed, vec!());
+                    let response = ResponseMessage::new(Response::Failed, ErrorCode::UnknownRequestType.as_u16().to_be_bytes().to_vec());
                     self.clone().send_response(writer, &response).await;
                     println!("[worker {:?}] read buffer error {:?}", std::thread::current().id(), command.unwrap_err());
                     return Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Failed to read buffer"));
@@ -411,7 +421,7 @@ impl Server {
                 let client_id = u128::from_be_bytes(buffer[COMMAND_SIZE..(COMMAND_SIZE+CLIENT_ID_SIZE)].try_into().unwrap());
                 let payload_size = u64::from_be_bytes(buffer[(COMMAND_SIZE+CLIENT_ID_SIZE)..(COMMAND_SIZE+CLIENT_ID_SIZE+PAYLOAD_SIZE)].try_into().unwrap());
                 if payload_size > MAX_PAYLOAD_SIZE {
-                    let response = ResponseMessage::new(Response::Failed, vec!());
+                    let response = ResponseMessage::new(Response::Failed, ErrorCode::PayloadTooLarge.to_payload());
                     self.clone().send_response(writer, &response).await;
                     println!("[worker {:?}] read buffer error MAX_PAYLOAD_SIZE reached", std::thread::current().id());
                     return Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Failed to read buffer"));
@@ -433,9 +443,10 @@ impl Server {
                         tokio::spawn(async move {
                             let Some(message) = server.get_message(message)
                             else {
-                                send_failed!(server, writer)
+                                send_failed!(server, writer, ErrorCode::RequestParseError)
                             };
-                            match server.get_queue(&queue_name).await {
+                            let queue_lock = server.queue.read().await;
+                            match server.get_queue(&queue_lock, &queue_name).await {
                                 Ok(queue) => {
                                     match queue.lock().await.enqueue(message.payload, client_id) {
                                         Ok(_) => {
@@ -443,14 +454,14 @@ impl Server {
                                             server.clone().send_response(writer, &response).await;
                                         }
                                         Err(err) => {
-                                            let response = ResponseMessage::new(Response::Failed, vec!());
+                                            let response = ResponseMessage::new(Response::Failed, ErrorCode::QueueIsEmpty.to_payload());
                                             server.clone().send_response(writer, &response).await;
                                             println!("[worker {:?}] enqueue error {:?}", std::thread::current().id(), err);
                                         }
                                     }
                                 },
                                 Err(err) => {
-                                    let response = ResponseMessage::new(Response::Failed, vec!());
+                                    let response = ResponseMessage::new(Response::Failed, err.to_payload());
                                     server.clone().send_response(writer, &response).await;
                                     println!("[worker {:?}] enqueue error {:?}", std::thread::current().id(), err);
                                 }
@@ -463,7 +474,7 @@ impl Server {
                             match server.clone().lock_and_dequeue_message(writer.clone(), queue_name, client_id).await {
                                 Ok(_) => {},
                                 Err(err) => {
-                                    let response = ResponseMessage::new(Response::Failed, vec!());
+                                    let response = ResponseMessage::new(Response::Failed, err.to_payload());
                                     server.clone().send_response(writer, &response).await;
                                     println!("[worker {:?}] send_message error {:?}", std::thread::current().id(), err);
                                 }
@@ -473,9 +484,10 @@ impl Server {
                     Request::CreateQ => {
                         let server = self.clone();
                         let mut queue_names = self.queue_names.write().await;
+                        let mut queue_lock = self.queue.write().await;
                         if queue_names.contains_key(&queue_name) {
                             tokio::spawn(async move {
-                                let response = ResponseMessage::new(Response::Failed, vec!());
+                                let response = ResponseMessage::new(Response::Failed, ErrorCode::QueueAlreadyExists.to_payload());
                                 server.send_response(writer, &response).await;
                                 println!("Queue already created!");
                             });
@@ -484,7 +496,7 @@ impl Server {
                         {
                             let hash = Uuid::new_v4();
                             queue_names.insert(queue_name, hash);
-                            self.queue.write().await.insert(hash, Arc::new(Mutex::new(Queue::new())));
+                            queue_lock.insert(hash, Arc::new(Mutex::new(Queue::new())));
                             tokio::spawn(async move {
                                 let response = ResponseMessage::new(Response::Succeeded, vec!());
                                 server.send_response(writer, &response).await;
@@ -494,10 +506,11 @@ impl Server {
                     Request::DeleteQ => {
                         let server = self.clone();
                         let mut queue_names = self.queue_names.write().await;
+                        let mut queue_lock = self.queue.write().await;
                         if queue_names.contains_key(&queue_name) {
                             let hash = queue_names.get(&queue_name).unwrap().clone();
                             queue_names.remove(&queue_name);
-                            self.queue.write().await.remove(&hash);
+                            queue_lock.remove(&hash);
                             tokio::spawn(async move {
                                 let response = ResponseMessage::new(Response::Succeeded, vec!());
                                 server.send_response(writer, &response).await;
@@ -505,7 +518,7 @@ impl Server {
                         }
                         else {
                             tokio::spawn(async move {
-                                let response = ResponseMessage::new(Response::Failed, vec!());
+                                let response = ResponseMessage::new(Response::Failed, ErrorCode::QueueDoesNotExist.to_payload());
                                 server.send_response(writer, &response).await;
                                 println!("Queue does not exist!");
                             });
@@ -514,11 +527,13 @@ impl Server {
                     Request::ListM => {
                         let server = self.clone();
                         tokio::spawn(async move {
-                            if server.queue_names.read().await.contains_key(&queue_name) {
-                                let hash = server.queue_names.read().await.get(&queue_name).unwrap().clone();
-                                if server.queue.read().await.contains_key(&hash)
+                            let queue_names = server.queue_names.read().await.clone();
+                            if queue_names.contains_key(&queue_name) {
+                                let hash = queue_names.get(&queue_name).unwrap().clone();
+                                let queue = server.queue.read().await.clone();
+                                if queue.contains_key(&hash)
                                 {
-                                    let list = server.queue.read().await.get(&hash).unwrap().lock().await.list_messages();
+                                    let list = queue.get(&hash).unwrap().lock().await.list_messages();
                                     let list = list.unwrap_or_else(|err| {
                                         println!("[worker {:?}] {}", std::thread::current().id(), err);
                                         vec!()
@@ -534,7 +549,7 @@ impl Server {
                                     }
                                 }
                             }
-                            let response = ResponseMessage::new(Response::Failed, vec!());
+                            let response = ResponseMessage::new(Response::Failed, ErrorCode::QueueHashNotFound.to_payload());
                             server.send_response(writer, &response).await;
                             println!("[worker {:?}] no queue exists {}", std::thread::current().id(), queue_name);
                         });
@@ -545,12 +560,13 @@ impl Server {
                         {
                             let Some(message) = server.get_message(message)
                             else {
-                                send_failed!(server, writer)
+                                send_failed!(server, writer, ErrorCode::RequestParseError)
                             };
-                            match server.get_queue(&queue_name).await {
+                            let queue_lock = server.queue.read().await;
+                            match server.get_queue(&queue_lock, &queue_name).await {
                                 Ok(queue) => {
                                     if payload_size < 16 {
-                                        invalid_message_id!(server, writer)
+                                        invalid_message_id!(server, writer, ErrorCode::PayloadMissingMessageId)
                                     }
                                     let bytes: [u8; 16] = message.payload[..16].try_into().unwrap();
                                     let message_id = u128::from_be_bytes(bytes);
@@ -560,14 +576,14 @@ impl Server {
                                             server.clone().send_response(writer, &response).await;
                                         }
                                         Err(err) => {
-                                            let response = ResponseMessage::new(Response::Failed, vec!());
+                                            let response = ResponseMessage::new(Response::Failed, ErrorCode::NoSuchMessageId.to_payload());
                                             server.clone().send_response(writer, &response).await;
                                             println!("[worker {:?}] delete message error {:?}", std::thread::current().id(), err);
                                         }
                                     }
                                 },
                                 Err(err) => {
-                                    let response = ResponseMessage::new(Response::Failed, vec!());
+                                    let response = ResponseMessage::new(Response::Failed, err.to_payload());
                                     server.clone().send_response(writer, &response).await;
                                     println!("[worker {:?}] delete message error {}", std::thread::current().id(), err);
                                 }
@@ -583,7 +599,7 @@ impl Server {
                                     server.clone().send_response(writer, &response).await;
                                 }
                                 Err(err) => {
-                                    let response = ResponseMessage::new(Response::Failed, vec!());
+                                    let response = ResponseMessage::new(Response::Failed, ErrorCode::NoSuchMessageIdLocked.to_payload());
                                     server.clone().send_response(writer, &response).await;
                                     println!("[worker {:?}] dequeue message error {:?}", std::thread::current().id(), err);
                                 }
@@ -593,24 +609,25 @@ impl Server {
                     Request::Failed => {
                         let server = self.clone();
                         tokio::spawn(async move {
-                           match server.get_queue(&queue_name).await {
-                               Ok(queue) => {
-                                   match queue.lock().await.unlock(client_id, None).await {
-                                       Ok(_) => {
-                                           let response = ResponseMessage::new(Response::Succeeded, vec!());
-                                           server.clone().send_response(writer, &response).await;
-                                       }
-                                       Err(err) => {
-                                           let response = ResponseMessage::new(Response::Failed, vec!());
-                                           server.clone().send_response(writer, &response).await;
-                                           println!("[worker {:?}] unlock message error {:?}", std::thread::current().id(), err);
+                            let queue_lock = server.queue.read().await;
+                            match server.get_queue(&queue_lock, &queue_name).await {
+                                Ok(queue) => {
+                                    match queue.lock().await.unlock(client_id, None).await {
+                                        Ok(_) => {
+                                            let response = ResponseMessage::new(Response::Succeeded, vec!());
+                                            server.clone().send_response(writer, &response).await;
+                                        }
+                                        Err(err) => {
+                                            let response = ResponseMessage::new(Response::Failed, ErrorCode::MessageNotLockedByClient.to_payload());
+                                            server.clone().send_response(writer, &response).await;
+                                            println!("[worker {:?}] unlock message error {:?}", std::thread::current().id(), err);
                                        }
                                    }
-                               },
-                               Err(err) => {
-                                   let response = ResponseMessage::new(Response::Failed, vec!());
-                                   server.clone().send_response(writer, &response).await;
-                                   println!("[worker {:?}] unlock message error {}", std::thread::current().id(), err);
+                                },
+                                Err(err) => {
+                                    let response = ResponseMessage::new(Response::Failed, err.to_payload());
+                                    server.clone().send_response(writer, &response).await;
+                                    println!("[worker {:?}] unlock message error {}", std::thread::current().id(), err);
                                }
                            }
                         });
@@ -620,12 +637,13 @@ impl Server {
                         tokio::spawn(async move {
                             let Some(message) = server.get_message(message)
                             else {
-                                send_failed!(server, writer)
+                                send_failed!(server, writer, ErrorCode::RequestParseError)
                             };
-                            match server.get_queue(&queue_name).await {
+                            let queue_lock = server.queue.read().await;
+                            match server.get_queue(&queue_lock, &queue_name).await {
                                 Ok(queue) => {
                                     if payload_size < 16 {
-                                        invalid_message_id!(server, writer)
+                                        invalid_message_id!(server, writer, ErrorCode::PayloadMissingMessageId)
                                     }
                                     let bytes: [u8; 16] = message.payload[..16].try_into().unwrap();
                                     let message_id = u128::from_be_bytes(bytes);
@@ -635,14 +653,14 @@ impl Server {
                                             server.clone().send_response(writer, &response).await;
                                         }
                                         Err(err) => {
-                                            let response = ResponseMessage::new(Response::Failed, vec!());
+                                            let response = ResponseMessage::new(Response::Failed, ErrorCode::MessageNotInQueue.to_payload());
                                             server.clone().send_response(writer, &response).await;
                                             println!("[worker {:?}] requeue message error {:?}", std::thread::current().id(), err);
                                         }
                                     }
                                 },
                                 Err(err) => {
-                                    let response = ResponseMessage::new(Response::Failed, vec!());
+                                    let response = ResponseMessage::new(Response::Failed, err.to_payload());
                                     server.clone().send_response(writer, &response).await;
                                     println!("[worker {:?}] requeue message error {}", std::thread::current().id(), err);
                                 }
@@ -654,15 +672,16 @@ impl Server {
                         tokio::spawn(async move {
                             let Some(mut message) = server.get_message(message)
                             else {
-                                send_failed!(server, writer)
+                                send_failed!(server, writer, ErrorCode::RequestParseError)
                             };
                             if payload_size < 16 {
-                                invalid_message_id!(server, writer)
+                                invalid_message_id!(server, writer, ErrorCode::PayloadMissingMessageId)
                             }
                             let bytes: [u8; 16] = message.payload[..16].try_into().unwrap();
                             let message_id = u128::from_be_bytes(bytes);
                             let payload = message.payload.split_off(16);
-                            match server.get_queue(&queue_name).await {
+                            let queue_lock = server.queue.read().await;
+                            match server.get_queue(&queue_lock, &queue_name).await {
                                 Ok(queue) => {
                                     match queue.lock().await.update_message(message_id, payload) {
                                         Ok(_) => {
@@ -670,14 +689,14 @@ impl Server {
                                             server.clone().send_response(writer, &response).await;
                                         }
                                         Err(err) => {
-                                            let response = ResponseMessage::new(Response::Failed, vec!());
+                                            let response = ResponseMessage::new(Response::Failed, ErrorCode::MessageNotInQueue.to_payload());
                                             server.clone().send_response(writer, &response).await;
                                             println!("[worker {:?}] update message error {:?}", std::thread::current().id(), err);
                                         }
                                     }
                                 },
                                 Err(err) => {
-                                    let response = ResponseMessage::new(Response::Failed, vec!());
+                                    let response = ResponseMessage::new(Response::Failed, err.to_payload());
                                     server.clone().send_response(writer, &response).await;
                                     println!("[worker {:?}] update message error {}", std::thread::current().id(), err);
                                 }
@@ -689,12 +708,13 @@ impl Server {
                         tokio::spawn(async move {
                             let Some(message) = server.get_message(message)
                             else {
-                                send_failed!(server, writer)
+                                send_failed!(server, writer, ErrorCode::RequestParseError)
                             };
-                            match server.get_queue(&queue_name).await {
+                            let queue_lock = server.queue.read().await;
+                            match server.get_queue(&queue_lock, &queue_name).await {
                                 Ok(queue) => {
                                     if payload_size < 1 {
-                                        let response = ResponseMessage::new(Response::Failed, vec!());
+                                        let response = ResponseMessage::new(Response::Failed, ErrorCode::InvalidConfigPayloadSize.to_payload());
                                         server.clone().send_response(writer, &response).await;
                                         println!("[worker {:?}] invalid config payload size {}", std::thread::current().id(), payload_size);
                                         return;
@@ -702,6 +722,10 @@ impl Server {
                                     let payload = message.payload.to_vec();
                                     match NetQueueConfig::from_be_bytes(payload) {
                                         Ok((net_queue_config, _)) => {
+                                            // TODO(bug): auto_fail and fail_timeout are updated under
+                                            // separate lock acquisitions. A concurrent Dequeue between
+                                            // them can read a half-updated config. Fix: hold a single
+                                            // lock for both updates.
                                             if net_queue_config.auto_fail().is_some() {
                                                 queue.lock().await.update_config_auto_fail(net_queue_config.auto_fail().unwrap());
                                             }
@@ -712,14 +736,14 @@ impl Server {
                                             server.clone().send_response(writer, &response).await;
                                         }
                                         Err(err) => {
-                                            let response = ResponseMessage::new(Response::Failed, vec!());
+                                            let response = ResponseMessage::new(Response::Failed, ErrorCode::ConfigBytesEmpty.to_payload());
                                             server.clone().send_response(writer, &response).await;
                                             println!("[worker {:?}] invalid config payload err {}", std::thread::current().id(), err);
                                         }
                                     }
                                 }
                                 Err(err) => {
-                                    let response = ResponseMessage::new(Response::Failed, vec!());
+                                    let response = ResponseMessage::new(Response::Failed, err.to_payload());
                                     server.clone().send_response(writer, &response).await;
                                     println!("[worker {:?}] update queue error {}", std::thread::current().id(), err);
                                 }

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -20,6 +20,8 @@ const COMMAND_SIZE: usize = 1usize;
 const PAYLOAD_SIZE: usize = 8usize;
 const CLIENT_ID_SIZE: usize = 16usize;
 const QUEUE_NAME_SIZE: usize = 64usize;
+// Will, probably, be modified later in config
+static MAX_PAYLOAD_SIZE: u64 = 4 * 1024 * 1024 * 1024;
 type Job = Pin<Box<dyn Future<Output = ()> + Send>>;
 #[derive(Debug)]
 pub(crate) struct Pool {
@@ -170,14 +172,14 @@ pub(crate) struct RequestMessage {
     // or use it (e.g. for logging which command a queued message originated from).
     command: Request,
     payload_size: u64,
-    payload: Vec<u8>,
+    payload: BytesMut,
 }
 impl RequestMessage {
-    pub(crate) fn new(command: &Request, bytes: BytesMut) -> Result<Self, std::io::Error> {
+    pub(crate) fn new(command: &Request, mut bytes: BytesMut) -> Result<Self, std::io::Error> {
         Ok(Self {
             command:  command.to_owned(),
             payload_size: u64::from_be_bytes(bytes[COMMAND_SIZE+CLIENT_ID_SIZE..COMMAND_SIZE+CLIENT_ID_SIZE+PAYLOAD_SIZE].try_into().unwrap()),
-            payload: bytes[COMMAND_SIZE+CLIENT_ID_SIZE+PAYLOAD_SIZE+QUEUE_NAME_SIZE..].to_vec(),
+            payload: bytes.split_off(COMMAND_SIZE+CLIENT_ID_SIZE+PAYLOAD_SIZE+QUEUE_NAME_SIZE),
         })
     }
 }
@@ -199,7 +201,7 @@ impl ResponseMessage {
         let mut bytes: Vec<u8> = Vec::new();
         bytes.push(self.status.clone() as u8);
         bytes.append(&mut self.payload_size.to_be_bytes().to_vec());
-        bytes.append(&mut self.payload.clone());
+        bytes.append(&mut self.payload.to_vec());
         bytes
     }
 }
@@ -408,6 +410,12 @@ impl Server {
                 let command = command.unwrap();
                 let client_id = u128::from_be_bytes(buffer[COMMAND_SIZE..(COMMAND_SIZE+CLIENT_ID_SIZE)].try_into().unwrap());
                 let payload_size = u64::from_be_bytes(buffer[(COMMAND_SIZE+CLIENT_ID_SIZE)..(COMMAND_SIZE+CLIENT_ID_SIZE+PAYLOAD_SIZE)].try_into().unwrap());
+                if payload_size > MAX_PAYLOAD_SIZE {
+                    let response = ResponseMessage::new(Response::Failed, vec!());
+                    self.clone().send_response(writer, &response).await;
+                    println!("[worker {:?}] read buffer error MAX_PAYLOAD_SIZE reached", std::thread::current().id());
+                    return Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Failed to read buffer"));
+                }
                 if buffer.len() < payload_size as usize + (COMMAND_SIZE+CLIENT_ID_SIZE+PAYLOAD_SIZE+QUEUE_NAME_SIZE) {
                     break;
                 }
@@ -464,7 +472,8 @@ impl Server {
                     }
                     Request::CreateQ => {
                         let server = self.clone();
-                        if self.queue_names.read().await.contains_key(&queue_name) {
+                        let mut queue_names = self.queue_names.write().await;
+                        if queue_names.contains_key(&queue_name) {
                             tokio::spawn(async move {
                                 let response = ResponseMessage::new(Response::Failed, vec!());
                                 server.send_response(writer, &response).await;
@@ -474,7 +483,7 @@ impl Server {
                         else
                         {
                             let hash = Uuid::new_v4();
-                            self.queue_names.write().await.insert(queue_name, hash);
+                            queue_names.insert(queue_name, hash);
                             self.queue.write().await.insert(hash, Arc::new(Mutex::new(Queue::new())));
                             tokio::spawn(async move {
                                 let response = ResponseMessage::new(Response::Succeeded, vec!());
@@ -484,9 +493,10 @@ impl Server {
                     }
                     Request::DeleteQ => {
                         let server = self.clone();
-                        if self.queue_names.read().await.contains_key(&queue_name) {
-                            let hash = self.queue_names.read().await.get(&queue_name).unwrap().clone();
-                            self.queue_names.write().await.remove(&queue_name);
+                        let mut queue_names = self.queue_names.write().await;
+                        if queue_names.contains_key(&queue_name) {
+                            let hash = queue_names.get(&queue_name).unwrap().clone();
+                            queue_names.remove(&queue_name);
                             self.queue.write().await.remove(&hash);
                             tokio::spawn(async move {
                                 let response = ResponseMessage::new(Response::Succeeded, vec!());
@@ -642,7 +652,7 @@ impl Server {
                     Request::UpdateM => {
                         let server = self.clone();
                         tokio::spawn(async move {
-                            let Some(message) = server.get_message(message)
+                            let Some(mut message) = server.get_message(message)
                             else {
                                 send_failed!(server, writer)
                             };
@@ -651,7 +661,7 @@ impl Server {
                             }
                             let bytes: [u8; 16] = message.payload[..16].try_into().unwrap();
                             let message_id = u128::from_be_bytes(bytes);
-                            let payload = message.payload[16..].to_vec();
+                            let payload = message.payload.split_off(16);
                             match server.get_queue(&queue_name).await {
                                 Ok(queue) => {
                                     match queue.lock().await.update_message(message_id, payload) {

--- a/src/tests/load_tests.rs
+++ b/src/tests/load_tests.rs
@@ -320,4 +320,55 @@ mod tests {
 
         stop_word.notify();
     }
+
+    // ============================================================================
+    // 1 GB payload round-trip (stress)
+    //
+    // Same shape as the 100 MB test but 10× larger. Verifies that the server
+    // can handle a single ~1 GB request frame end-to-end: allocation, storage,
+    // and faithful dequeue. Peak RSS will be at least ~2 GB (request buffer +
+    // stored message + outbound write buffer). Timeouts are generous to
+    // accommodate slower CI machines.
+    // ============================================================================
+    #[ignore]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn large_payload_roundtrip_1gb() {
+        const SIZE: usize = 1024 * 1024 * 1024; // 1 GB
+        const META_LEN: usize = 56;
+        const QNAME: &str = "gbq";
+
+        let (address, stop_word) = start_loaded_server(2, 8).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        create_queue(&mut client, 1, QNAME).await;
+
+        // Deterministic pattern so we can check every byte without storing a copy elsewhere.
+        let payload: Vec<u8> = (0..SIZE).map(|i| (i % 251) as u8).collect();
+
+        let start = Instant::now();
+        client.write_all(&encode_request(1, 1, QNAME, &payload)).await.unwrap();
+        let (status, _) = read_response(&mut client, Duration::from_secs(300)).await;
+        assert_eq!(status, 1, "Enqueue 1GB: expected Succeeded");
+        let enq_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        client.write_all(&encode_request(2, 1, QNAME, &[])).await.unwrap();
+        let (status, response_payload) = read_response(&mut client, Duration::from_secs(300)).await;
+        let deq_elapsed = start.elapsed();
+        assert_eq!(status, 1, "Dequeue 1GB: expected Succeeded");
+        assert_eq!(response_payload.len(), META_LEN + SIZE, "dequeue response size mismatch");
+
+        let got = &response_payload[META_LEN..];
+        assert_eq!(got.len(), SIZE, "payload length mismatch");
+        // Use `==` on raw slices — assert_eq! would dump 1 GB into the test log on failure.
+        assert!(got == payload.as_slice(), "1GB payload byte mismatch on round-trip");
+
+        let mbps_enq = (SIZE as f64 / (1024.0 * 1024.0)) / enq_elapsed.as_secs_f64();
+        let mbps_deq = (SIZE as f64 / (1024.0 * 1024.0)) / deq_elapsed.as_secs_f64();
+        println!(
+            "large_payload_roundtrip_1gb: enqueue {:?} ({:.1} MB/s), dequeue {:?} ({:.1} MB/s)",
+            enq_elapsed, mbps_enq, deq_elapsed, mbps_deq
+        );
+
+        stop_word.notify();
+    }
 }

--- a/src/tests/server_tests.rs
+++ b/src/tests/server_tests.rs
@@ -771,4 +771,103 @@ mod tests {
 
         stop_word.notify();
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn server_failed_response_carries_error_code_payload() {
+        // Verify that Failed responses contain a 2-byte ErrorCode payload (big-endian u16).
+        use crate::errors::ErrorCode;
+
+        let address = free_local_addr();
+        let drained = Arc::new(Notify::new());
+        let (stop_word, _) = start_server(make_config(address), drained).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+
+        // Enqueue to nonexistent queue → QueueHashNotFound (100)
+        client.write_all(&encode_request(1, 1, "noqueue", b"data")).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 2, "expected Failed");
+        let error_payload = &response[9..];
+        assert_eq!(error_payload.len(), 2, "Failed payload should be 2 bytes (error code)");
+        let code = u16::from_be_bytes(error_payload.try_into().unwrap());
+        assert_eq!(
+            ErrorCode::from_u16(code),
+            Some(ErrorCode::QueueHashNotFound),
+            "expected QueueHashNotFound error code"
+        );
+
+        stop_word.notify();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn server_dequeue_nonexistent_queue_responds_failure() {
+        use crate::errors::ErrorCode;
+
+        let address = free_local_addr();
+        let drained = Arc::new(Notify::new());
+        let (stop_word, _) = start_server(make_config(address), drained).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+
+        // Dequeue from a queue that was never created
+        client.write_all(&encode_request(2, 1, "noqueue", &[])).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 2, "Dequeue nonexistent queue: expected Failed");
+        let code = u16::from_be_bytes(response[9..11].try_into().unwrap());
+        assert_eq!(
+            ErrorCode::from_u16(code),
+            Some(ErrorCode::QueueHashNotFound),
+            "expected QueueHashNotFound error code"
+        );
+
+        stop_word.notify();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn server_succeeded_without_lock_responds_failure() {
+        let address = free_local_addr();
+        let drained = Arc::new(Notify::new());
+        let (stop_word, _) = start_server(make_config(address), drained).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+
+        client.write_all(&encode_request(3, 1, "ackq2", &[])).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 1, "CreateQ: expected Succeeded");
+
+        client.write_all(&encode_request(1, 1, "ackq2", b"data")).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 1, "Enqueue: expected Succeeded");
+
+        // Succeeded (7) without dequeuing first — no locked message for this client
+        client.write_all(&encode_request(7, 1, "ackq2", &[])).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 2, "Succeeded without lock: expected Failed");
+
+        stop_word.notify();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn server_requeue_short_payload_responds_failure() {
+        let address = free_local_addr();
+        let drained = Arc::new(Notify::new());
+        let (stop_word, _) = start_server(make_config(address), drained).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+
+        client.write_all(&encode_request(3, 1, "reqq2", &[])).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 1, "CreateQ: expected Succeeded");
+
+        // Requeue (9) with payload shorter than 16 bytes (no valid message_id)
+        client.write_all(&encode_request(9, 1, "reqq2", b"short")).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 2, "Requeue short payload: expected Failed");
+
+        stop_word.notify();
+    }
 }

--- a/src/tests/server_tests.rs
+++ b/src/tests/server_tests.rs
@@ -718,4 +718,57 @@ mod tests {
             .await.expect("server did not drain within 5 seconds")
             .unwrap();
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn server_enqueue_nonexistent_queue_responds_failure() {
+        let address = free_local_addr();
+        let drained = Arc::new(Notify::new());
+        let (stop_word, _) = start_server(make_config(address), drained).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+
+        client.write_all(&encode_request(1, 1, "noqueue", b"data")).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 2, "Enqueue to nonexistent queue: expected Failed");
+
+        stop_word.notify();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn server_delete_message_short_payload_responds_failure() {
+        let address = free_local_addr();
+        let drained = Arc::new(Notify::new());
+        let (stop_word, _) = start_server(make_config(address), drained).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+
+        client.write_all(&encode_request(3, 1, "delmq2", &[])).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 1, "CreateQ: expected Succeeded");
+
+        // DeleteM with payload shorter than 16 bytes (no valid message_id)
+        client.write_all(&encode_request(6, 1, "delmq2", b"short")).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 2, "DeleteM short payload: expected Failed");
+
+        stop_word.notify();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn server_list_messages_nonexistent_queue_responds_failure() {
+        let address = free_local_addr();
+        let drained = Arc::new(Notify::new());
+        let (stop_word, _) = start_server(make_config(address), drained).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+
+        client.write_all(&encode_request(5, 1, "noqueue", &[])).await.unwrap();
+        let response = read_response(&mut client).await;
+        assert_eq!(response[0], 2, "ListM on nonexistent queue: expected Failed");
+
+        stop_word.notify();
+    }
 }


### PR DESCRIPTION
  Summary                                                                                                                                                                                                                                                                      
  Failed responses now carry a typed 2-byte ErrorCode payload instead of an empty body, letting clients programmatically distinguish error conditions. Several race conditions in the server's shared-state handling were also fixed: CreateQ/DeleteQ are now atomic, 
  get_queue holds a read guard for the full operation, lock_and_dequeue_message returns typed errors, and the auto_fail deadlock is resolved.                                                                                                                            
  Changes                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                      
  Error codes (src/errors.rs, src/main.rs)                                                                                                                                                                                                                               
  - New ErrorCode enum (#[repr(u16)], 18 variants across 4 categories: general 0–99, queue 100–199, message 200–299, config 300–399) with as_u16(), to_payload(), from_u16(), and Display impls (901fcb0)                                                             
  - mod errors added to main.rs                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                        Server — typed error responses (src/net/server.rs)                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                      
  - Every ResponseMessage::new(Response::Failed, vec!()) replaced with ErrorCode::*.to_payload() across all 11 command handlers (901fcb0)                                                                                                                             
  - send_failed! and invalid_message_id! macros now accept an $err: expr parameter and serialize it as a 2-byte BE u16 (901fcb0)
  - send_response return type changed from () to Option<ErrorCode> to surface write failures (901fcb0)                                                                                                                                                                
                                                                                                                                                                                                                                                                      
  Server — race condition fixes (src/net/server.rs)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
  - get_queue now takes &RwLockReadGuard instead of acquiring its own read lock, so callers hold the guard for the full operation — prevents stale-Arc after concurrent DeleteQ (25f012f, 2ffd41a)                                                                    
  - All get_queue call sites (Enqueue, Dequeue, DeleteM, Succeeded, Failed, Requeue, UpdateM, UpdateQ) updated to acquire server.queue.read().await before calling get_queue (25f012f, 2ffd41a)                                                                     
  - CreateQ / DeleteQ: now hold both queue_names.write() and queue.write() simultaneously, making two-map insertion/removal atomic (25f012f)                                                                                                                          
  - ListM: clones both queue_names and queue HashMaps to avoid borrow-vs-move conflict with send_response (25f012f)                                                                                                                                                   
  - UpdateQ: auto_fail and fail_timeout now updated under a single queue.lock().await instead of two separate acquisitions (2ffd41a)                                                                                                                                  
                                                                                                                                                                                                                                                                        Server — dequeue error propagation (src/net/server.rs)                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                      
  - lock_and_dequeue_message return type changed from Result<(), io::Error> to Result<(), ErrorCode> — lock_to_read errors mapped by string to QueueIsEmpty/NoSuchMessageId/MessageAlreadyLocked (901fcb0)                                                            
  - Auto_fail config read now uses a single lock acquisition; guard is explicitly drop()-ed before the sleep to prevent deadlock on re-acquisition (2ffd41a)
                                                                                                                                                                                                                                                                        Server — payload guard (src/net/server.rs)                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                      
  - MAX_PAYLOAD_SIZE constant (4 GB) added; read_buffer rejects payload_size > MAX_PAYLOAD_SIZE with ErrorCode::PayloadTooLarge before buffering (901fcb0)                                                                                                               
  Queue — BytesMut migration (src/net/queue.rs)                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                      
  - QueueMessage::payload changed from Vec<u8> to BytesMut; enqueue(), update_message(), and QueueMessage::new() signatures updated accordingly — avoids a copy in RequestMessage::new via split_off instead of to_vec() (901fcb0)                                       
  Version bump (Cargo.toml, Cargo.lock)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
  - 0.5.0 → 0.5.2                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                      
  Docs (CLAUDE.md)                                                                                                                                                                                                                                                       
  - Added Review Rules section                                                                                                                                                                                                                                        
  - Documented ErrorCode in Key Types table and response format                                                                                                                                                                                                       
  - Updated Known Design Limitations: removed stale DoS surface note (now guarded by MAX_PAYLOAD_SIZE)                                                                                                                                                                
                                                                                                                                                                                                                                                                        Tests                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                      
  New tests (8 in server_tests.rs, 1 in load_tests.rs):                                                                                                                                                                                                                  
  ┌─────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────┐                                                                                                                               │                          Test                           │                              Guards against                               │                                                                                                                             
  ├─────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤                                                                                                                             
  │ server_enqueue_nonexistent_queue_responds_failure       │ Enqueue to missing queue returns Failed                                   │                                                                                                                             
  ├─────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ server_delete_message_short_payload_responds_failure    │ DeleteM with < 16-byte payload returns Failed                             │
  ├─────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤                                                                                                                               │ server_list_messages_nonexistent_queue_responds_failure │ ListM on missing queue returns Failed                                     │
  ├─────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤                                                                                                                               │ server_failed_response_carries_error_code_payload       │ Failed responses carry correct 2-byte ErrorCode (QueueHashNotFound = 100) │                                                                                                                             
  ├─────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤                                                                                                                               │ server_dequeue_nonexistent_queue_responds_failure       │ Dequeue from missing queue returns QueueHashNotFound error code           │                                                                                                                             
  ├─────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤                                                                                                                               │ server_succeeded_without_lock_responds_failure          │ Succeeded without prior Dequeue returns Failed                            │                                                                                                                             
  ├─────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤                                                                                                                               │ server_requeue_short_payload_responds_failure           │ Requeue with < 16-byte payload returns Failed                             │                                                                                                                             
  ├─────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤                                                                                                                             
  │ large_payload_roundtrip_1gb                             │ (ignored) 1 GB round-trip stress test                                     │                                                                                                                             
  └─────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────┘                                                                                                                                
  Local results: cargo test — 32 passed, 0 failed, 5 ignored. Load tests not run (require --release --ignored).                                                                                                                                                                                                                                                                                                                                                                                                                             
  Known residual issues / out of scope                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                      
  - TODO(cleanup) in server.rs:173 — command field in RequestMessage stored but never read                                                                                                                                                                            
  - TODO(note) in queue.rs:181 — u128 overflow wraps to 1, may silently overwrite an existing message
  - TODO(design) in config.rs:31 — PROC_LIMIT parsed but never used                                                                                                                                                                                                   
  - lock_to_read errors are mapped to ErrorCode via string matching ("Queue is empty", etc.) — fragile but functional; a typed error enum in Queue would be cleaner                                                                                                   
                                                                                                                                                                                                                                                                        Risk & review focus                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                      
  The highest-risk change is the get_queue refactor to &RwLockReadGuard — it touches every command handler and changes lock lifetimes. Verify that no handler drops the read guard before it's done with the queue (all look correct: guard lives to end of             tokio::spawn block). The auto_fail drop(lock) before sleep is also worth scrutinizing to ensure the guard is truly released before re-acquisition.
